### PR TITLE
Fix/safari base64 parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@thatzokay/vue-aplayer",
-  "version": "3.0.1",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thatzokay/vue-aplayer",
-      "version": "3.0.1",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "hls.js": "^1.5.18",
+        "music-metadata": "^10.6.5",
         "ua-parser-js": "^2.0.0",
         "vue": "^3.5.13"
       },
@@ -25,7 +26,6 @@
         "eslint": "^9.17.0",
         "eslint-plugin-vue": "^9.32.0",
         "globals": "^15.14.0",
-        "music-metadata": "^10.6.5",
         "postcss": "^8.4.49",
         "rimraf": "^6.0.1",
         "sass-embedded": "^1.83.1",
@@ -1896,7 +1896,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@shikijs/core": {
@@ -1989,7 +1988,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3068,7 +3066,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3198,7 +3195,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3732,7 +3728,6 @@
       "version": "19.6.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
       "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-stream": "^9.0.1",
@@ -3751,7 +3746,6 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
       "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -3886,7 +3880,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
@@ -4065,7 +4058,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4241,7 +4233,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4348,7 +4339,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/link/-/link-2.1.1.tgz",
       "integrity": "sha512-NV3AUVYBovJ6eVQcTeRoPnZSxzt2LOijNd+ugEZKRy/XeQlpTRhVRkuDv5kOlXwMAUx30vfUc7asRFb9RT65yg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "link": "dist/cli.js"
@@ -4597,7 +4587,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {
@@ -4611,7 +4600,6 @@
       "version": "10.6.5",
       "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-10.6.5.tgz",
       "integrity": "sha512-mcBVcjfG+ybyRNDU/llqwtoNZzjoFWjWoazlN6yxBdkzu5YI8mF5SE67fX4OPao19YNholBYFetLUc/qnkLiSg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4642,7 +4630,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4884,7 +4871,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.3.1.tgz",
       "integrity": "sha512-GVlENSDW6KHaXcd9zkZltB7tCLosKB/4Hg0fqBJkAoBgYG2Tn1xtMgXtSUuMU9AK/gCm/tTdT8mgAeF4YNeeqw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -6024,7 +6010,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.0.1.tgz",
       "integrity": "sha512-7OOJepVlvlcgjW/fLNCsIqpNleAoi1y0LTRWGnOpABOSpRmw+65HvnruoOCnjpaQ1efnlYpQ/JwHKuaombnuXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -6269,7 +6254,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
       "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -6432,7 +6416,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
       "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@thatzokay/vue-aplayer",
   "private": false,
   "description": "A beautiful HTML5 music player for Vue.js",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "author": "ThatzOkay",
   "license": "MIT",
   "homepage": "https://github.com/ThatzOkay/vue-aplayer#readme",
@@ -59,6 +59,7 @@
   "dependencies": {
     "hls.js": "^1.5.18",
     "ua-parser-js": "^2.0.0",
+    "music-metadata": "^10.6.5",
     "vue": "^3.5.13"
   },
   "devDependencies": {
@@ -73,7 +74,6 @@
     "eslint": "^9.17.0",
     "eslint-plugin-vue": "^9.32.0",
     "globals": "^15.14.0",
-    "music-metadata": "^10.6.5",
     "postcss": "^8.4.49",
     "rimraf": "^6.0.1",
     "sass-embedded": "^1.83.1",

--- a/src/Components/APlayer.vue
+++ b/src/Components/APlayer.vue
@@ -65,9 +65,8 @@
   import Lyric from './Lyric.vue';
   import { events, ReadyState } from '@/vue-audio';
   import VueAudio from '@/vue-audio';
-  import { parseBlob, parseBuffer } from 'music-metadata';
+  import { parseBuffer } from 'music-metadata';
   import type { AudioType } from '@/types/aplayer';
-import { UAParser } from 'ua-parser-js';
   
   const props = withDefaults(defineProps<Options>(), {
     fixed: false,

--- a/src/Components/APlayer.vue
+++ b/src/Components/APlayer.vue
@@ -640,32 +640,6 @@ console.log("store: ", store)
       fetchImage();
     });
   };
-  
-  const base64ToBlob = (base64: string, mime: string) => {
-    mime = mime || '';
-    var sliceSize = 1024;
-    var byteChars = window.atob(base64);
-    var byteArrays = [];
-  
-    for (
-      var offset = 0, len = byteChars.length;
-      offset < len;
-      offset += sliceSize
-    ) {
-      var slice = byteChars.slice(offset, offset + sliceSize);
-  
-      var byteNumbers = new Array(slice.length);
-      for (var i = 0; i < slice.length; i++) {
-        byteNumbers[i] = slice.charCodeAt(i);
-      }
-  
-      var byteArray = new Uint8Array(byteNumbers);
-  
-      byteArrays.push(byteArray);
-    }
-  
-    return new Blob(byteArrays, { type: mime });
-  };
 
   const base64ToByteArray = (base64: string): Uint8Array => {
     const sliceSize = 1024;


### PR DESCRIPTION
Safari gives TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController when using bob because Safari does not support this. This fixes that to use a buffer instead which works.